### PR TITLE
Add user names to API user model

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -50,6 +50,9 @@ jobs:
             - name: Install dependencies
               run: npm install
 
+            - name: Build Shared Lib
+              run: yarn workspace @orion/shared build
+
             # - name: Run API tests
             #   run: npm run test:api-p
             - name: Run API tests

--- a/packages/api/src/modules/user/User.ts
+++ b/packages/api/src/modules/user/User.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { Field, ID, ObjectType } from 'type-graphql';
 
 @ObjectType({ description: 'The user model' })
@@ -6,7 +7,18 @@ class User {
     id!: string;
 
     @Field(() => String)
+    firstName!: string;
+
+    @Field(() => String)
+    lastName!: string;
+
+    @Field(() => String)
     email!: string;
+
+    @Field(() => String, { nullable: true })
+    displayName(): string | null {
+        return `${this.firstName} ${this.lastName}`;
+    }
 
     password!: string;
 }

--- a/packages/api/src/modules/user/UserResolver.ts
+++ b/packages/api/src/modules/user/UserResolver.ts
@@ -34,6 +34,12 @@ class RegisterUserPayload {
 @InputType()
 class RegisterUserInput {
     @Field()
+    firstName!: string;
+
+    @Field()
+    lastName!: string;
+
+    @Field()
     @IsEmail()
     email!: string;
 
@@ -41,7 +47,7 @@ class RegisterUserInput {
     password!: string;
 }
 
-@Resolver()
+@Resolver((of) => User)
 class UserResolver {
     @Query(() => [User])
     users(@Ctx() { dataSources }: AppContext): Promise<User[]> {
@@ -58,7 +64,12 @@ class UserResolver {
         @Arg('userData') userData: RegisterUserInput,
         @Ctx() { dataSources }: AppContext
     ): Promise<RegisterUserPayload> {
-        const newUser = await dataSources.userService.createUser(userData.email, userData.password);
+        const newUser = await dataSources.userService.createUser(
+            userData.firstName,
+            userData.lastName,
+            userData.email,
+            userData.password
+        );
         return { user: newUser };
     }
 }

--- a/packages/api/src/modules/user/UserService.ts
+++ b/packages/api/src/modules/user/UserService.ts
@@ -12,12 +12,19 @@ class UserService extends DataSource {
         super();
     }
 
-    createUser(email: string, password: string): Promise<User> {
-        const newUser = {
-            id: v4(),
-            email,
-            password
-        };
+    createUser(
+        firstName: string,
+        lastName: string,
+        email: string,
+        password: string
+    ): Promise<User> {
+        const newUser = new User();
+
+        newUser.id = v4();
+        newUser.firstName = firstName;
+        newUser.lastName = lastName;
+        newUser.email = email;
+        newUser.password = password;
 
         users = [...users, newUser];
         return Promise.resolve(newUser);

--- a/packages/api/src/modules/user/__tests__/userService.test.ts
+++ b/packages/api/src/modules/user/__tests__/userService.test.ts
@@ -13,7 +13,12 @@ describe('User service', () => {
 
     describe('createUser()', () => {
         it('creates a new user', async () => {
-            const result = await userService?.createUser('oliver@qc.com', 'secret');
+            const result = await userService?.createUser(
+                'Oliver',
+                'Queen',
+                'oliver@qc.com',
+                'secret'
+            );
 
             expect(result).toEqual(
                 expect.objectContaining({
@@ -27,7 +32,7 @@ describe('User service', () => {
 
     describe('getAllUsers()', () => {
         beforeAll(async () => {
-            await userService.createUser('barry@starlabs.com', 'theflash');
+            await userService.createUser('Barry', 'Allen', 'barry@starlabs.com', 'theflash');
         });
 
         it('fetches all users', async () => {
@@ -40,9 +45,14 @@ describe('User service', () => {
         let userId: string;
 
         beforeAll(async () => {
-            await userService.createUser('barry@starlabs.com', 'theflash');
+            await userService.createUser('Barry', 'Allen', 'barry@starlabs.com', 'theflash');
 
-            const vibe = await userService.createUser('cisco@starlabs.com', 'thevibe');
+            const vibe = await userService.createUser(
+                'Cisco',
+                'Ramon',
+                'cisco@starlabs.com',
+                'thevibe'
+            );
             userId = vibe.id;
         });
 
@@ -54,8 +64,8 @@ describe('User service', () => {
 
     describe('removeAllUsers()', () => {
         beforeAll(async () => {
-            await userService.createUser('barry@starlabs.com', 'theflash');
-            await userService.createUser('cisco@starlabs.com', 'thevibe');
+            await userService.createUser('Barry', 'Allen', 'barry@starlabs.com', 'theflash');
+            await userService.createUser('Cisco', 'Ramon', 'cisco@starlabs.com', 'thevibe');
         });
 
         it('clears all users', async () => {

--- a/packages/api/src/testutils/index.ts
+++ b/packages/api/src/testutils/index.ts
@@ -1,5 +1,7 @@
 import request from 'supertest';
 import Express from 'express';
+import { oliver, barry, dig, cisco } from './userData';
+import { GetUserOp, RegisterUserOp, UserQuery } from './userQueries';
 
 export const makeGraphQLCall = (
     app: Express.Application,
@@ -11,3 +13,5 @@ export const makeGraphQLCall = (
         .set('Content-Type', 'application/json')
         .send({ query, variables });
 };
+
+export { oliver, dig, barry, cisco, GetUserOp, RegisterUserOp, UserQuery };

--- a/packages/api/src/testutils/userData.ts
+++ b/packages/api/src/testutils/userData.ts
@@ -1,0 +1,27 @@
+export const oliver = {
+    firstName: 'Oliver',
+    lastName: 'Queen',
+    email: 'oliver@qc.com',
+    password: '123456'
+};
+
+export const dig = {
+    firstName: 'John',
+    lastName: 'Diggle',
+    email: 'dig@qc.com',
+    password: '123456'
+};
+
+export const barry = {
+    firstName: 'Barry',
+    lastName: 'Allen',
+    email: 'barry@starlabs.com',
+    password: '123456'
+};
+
+export const cisco = {
+    firstName: 'Cisco',
+    lastName: 'Ramon',
+    email: 'cisco@starlabs.com',
+    password: '123456'
+};

--- a/packages/api/src/testutils/userQueries.ts
+++ b/packages/api/src/testutils/userQueries.ts
@@ -1,0 +1,34 @@
+export const RegisterUserOp = `
+mutation RegisterUser($userData: RegisterUserInput!) {
+    registerUser(userData: $userData) {
+        user {
+            id
+            firstName
+            lastName
+            displayName
+            email
+        }
+    }
+}`;
+
+export const UserQuery = `
+query {
+    users {
+        id
+        firstName
+        lastName
+        displayName
+        email
+    }
+}`;
+
+export const GetUserOp = `
+query GetUser($id: String!){
+    user(id: $id) {
+        id
+        firstName
+        lastName
+        displayName
+        email
+    }
+}`;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,6 +20,7 @@
     "scripts": {
         "build": "tsc --build tsconfig.json",
         "clean": "rm -rf dist",
+        "pretest":"yarn build",
         "test": "NODE_ENV=testing jest --color --runInBand"
     },
     "bugs": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,7 +20,6 @@
     "scripts": {
         "build": "tsc --build tsconfig.json",
         "clean": "rm -rf dist",
-        "pretest":"yarn build",
         "test": "NODE_ENV=testing jest --color --runInBand"
     },
     "bugs": {


### PR DESCRIPTION
Add `firstName`, `lastName`. and (virtual) `displayName` properties to the user model and queries.