### PR TITLE
Change names of resolver queries

### DIFF
--- a/packages/api-v2/.eslintrc.js
+++ b/packages/api-v2/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
         '@typescript-eslint/interface-name-prefix': 'off',
         '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
-        '@typescript-eslint/no-explicit-any': 'off'
+        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }]
     }
 };

--- a/packages/api-v2/src/modules/status/__tests__/status.resolver.spec.ts
+++ b/packages/api-v2/src/modules/status/__tests__/status.resolver.spec.ts
@@ -19,6 +19,6 @@ describe('StatusResolver', () => {
     });
 
     it('has staus() method', () => {
-        expect(resolver.status()).toBe(constants.STATUS_MESSAGE);
+        expect(resolver.getStatus()).toBe(constants.STATUS_MESSAGE);
     });
 });

--- a/packages/api-v2/src/modules/status/status.resolver.ts
+++ b/packages/api-v2/src/modules/status/status.resolver.ts
@@ -5,8 +5,8 @@ import { StatusService } from './status.service';
 export class StatusResolver {
     constructor(private readonly statusService: StatusService) {}
 
-    @Query((returns) => String)
-    status(): string {
+    @Query((_returns) => String, { name: 'status' })
+    getStatus(): string {
         return this.statusService.getMessage();
     }
 }

--- a/packages/api-v2/src/modules/user/__tests__/user.resolver.spec.ts
+++ b/packages/api-v2/src/modules/user/__tests__/user.resolver.spec.ts
@@ -43,7 +43,7 @@ describe('User resolver', () => {
             const result = [];
             const getAllUsersSpy = jest.spyOn(userService, 'getAllUsers').mockResolvedValue(result);
 
-            expect(await userResolver.users()).toBe(result);
+            expect(await userResolver.getUsers()).toBe(result);
             expect(getAllUsersSpy).toHaveBeenCalled();
         });
     });

--- a/packages/api-v2/src/modules/user/user.resolver.ts
+++ b/packages/api-v2/src/modules/user/user.resolver.ts
@@ -30,12 +30,12 @@ class RegisterUserInput {
 export class UserResolver {
     constructor(private readonly userService: UserService) {}
 
-    @Query(() => [User])
-    users(): Promise<User[]> {
+    @Query(() => [User], { name: 'users' })
+    getUsers(): Promise<User[]> {
         return this.userService.getAllUsers();
     }
 
-    @ResolveField('displayName', (returns) => String)
+    @ResolveField('displayName', (_returns) => String)
     getDisplayName(@Parent() user: User) {
         return `${user.firstName} ${user.lastName}`;
     }


### PR DESCRIPTION
Refactor the names of resolver queries and utilize the decorator config name property.