### PR TITLE
Update response to send unauthorized exception on failed login attempt

### DIFF
--- a/packages/api/src/modules/auth/__tests__/auth.resolver.spec.ts
+++ b/packages/api/src/modules/auth/__tests__/auth.resolver.spec.ts
@@ -1,0 +1,73 @@
+import { Test } from '@nestjs/testing';
+import { AuthService } from '../auth.service';
+import { AuthResolver } from '../auth.resolver';
+import { UserModule } from '../../user/user.module';
+import { UserService } from '../../user/user.service';
+import { JwtModule } from '@nestjs/jwt';
+import { CreateUserDto } from '../../user/create-user.dto';
+import { UnauthorizedException } from '@nestjs/common';
+
+const oliver: CreateUserDto = {
+    firstName: 'Ollie',
+    lastName: 'Queen',
+    email: 'oliver@qc.com',
+    password: '123456'
+};
+
+describe('Auth resolver', () => {
+    let authService: AuthService;
+    let userService: UserService;
+    let authResolver: AuthResolver;
+
+    beforeEach(async () => {
+        const moduleRef = await Test.createTestingModule({
+            imports: [
+                UserModule,
+                JwtModule.register({
+                    secret: 'tempjwtsecret' // TODO: move this 'secret' to a config env file
+                })
+            ],
+            providers: [AuthResolver, AuthService]
+        }).compile();
+
+        authService = moduleRef.get<AuthService>(AuthService);
+        userService = moduleRef.get<UserService>(UserService);
+        authResolver = moduleRef.get<AuthResolver>(AuthResolver);
+    });
+
+    describe('login mutation', () => {
+        it('returns an access token if user is authenticated', async () => {
+            const expectedToken = 'randomToken123456';
+            const ollie = userService.create(oliver);
+
+            jest.spyOn(authService, 'authenticateUser').mockResolvedValue(ollie);
+            jest.spyOn(authService, 'generateAccessToken').mockResolvedValue(expectedToken);
+
+            const result = await authResolver.login(oliver.email, oliver.password);
+
+            expect(result).toEqual(
+                expect.objectContaining({
+                    accessToken: expectedToken
+                })
+            );
+        });
+
+        it('returns an Unauthorized exception if user is not authenticated', async () => {
+            jest.spyOn(authService, 'authenticateUser').mockResolvedValue(null);
+
+            const error = (await authResolver.login(
+                'unknown-user@example.com',
+                'secret'
+            )) as UnauthorizedException;
+
+            expect(error instanceof UnauthorizedException).toBe(true);
+            expect(error.getStatus()).toBe(401);
+            expect(error.getResponse()).toEqual(
+                expect.objectContaining({
+                    message: 'Unauthorized',
+                    statusCode: 401
+                })
+            );
+        });
+    });
+});

--- a/packages/api/src/modules/auth/auth.resolver.ts
+++ b/packages/api/src/modules/auth/auth.resolver.ts
@@ -1,3 +1,4 @@
+import { UnauthorizedException } from '@nestjs/common';
 import { Args, Field, Mutation, ObjectType, Resolver } from '@nestjs/graphql';
 import { AuthService } from './auth.service';
 
@@ -15,12 +16,14 @@ export class AuthResolver {
     async login(
         @Args('email') email: string,
         @Args('password') password: string
-    ): Promise<LoginResponse | undefined> {
+    ): Promise<LoginResponse | UnauthorizedException> {
         const authUser = await this.authService.authenticateUser(email, password);
-        let accessToken: string | null = null;
-        if (authUser) {
-            accessToken = await this.authService.generateAccessToken(authUser);
+
+        if (!authUser) {
+            return new UnauthorizedException();
         }
+
+        const accessToken = await this.authService.generateAccessToken(authUser);
         return {
             accessToken
         };

--- a/packages/api/test/auth.e2e-spec.ts
+++ b/packages/api/test/auth.e2e-spec.ts
@@ -51,6 +51,7 @@ describe('Auth resolver (e2e)', () => {
 
         it('does not authenticate a user with an invalid email', async () => {
             await userService.create(oliver);
+
             return request(app.getHttpServer())
                 .post('/graphql')
                 .set('Content-Type', 'application/json')
@@ -59,13 +60,15 @@ describe('Auth resolver (e2e)', () => {
                     variables: { email: 'unknown-email@qc.com', password: oliver.password }
                 })
                 .expect(({ body }) => {
-                    const { accessToken } = body.data.login;
-                    expect(accessToken).toBeNull();
+                    expect(body.data).toBeNull();
+                    expect(body.errors).toHaveLength(1);
+                    expect(body.errors[0].message).toBe('Unauthorized');
                 });
         });
 
         it('does not authenticate a user with an invalid password', async () => {
             await userService.create(oliver);
+
             return request(app.getHttpServer())
                 .post('/graphql')
                 .set('Content-Type', 'application/json')
@@ -74,8 +77,10 @@ describe('Auth resolver (e2e)', () => {
                     variables: { email: oliver.email, password: 'wrong-password' }
                 })
                 .expect(({ body }) => {
-                    const { accessToken } = body.data.login;
-                    expect(accessToken).toBeNull();
+                    expect(body.data).toBeNull();
+                    expect(body.errors).toHaveLength(1);
+                    expect(body.errors[0].message).toBe('Unauthorized');
+                    expect(body.errors[0].extensions.exception.status).toBe(401);
                 });
         });
     });


### PR DESCRIPTION
Update api response to send an unauthorized exception (error) on failed login attempt.

Fixes #32 