### PR TITLE
Integrate avatar upload with API

### DIFF
--- a/packages/api/src/modules/avatar/avatar.resolver.ts
+++ b/packages/api/src/modules/avatar/avatar.resolver.ts
@@ -1,5 +1,4 @@
-// import { Stream } from 'stream';
-import fs, { createWriteStream } from 'fs';
+import { Writable } from 'stream';
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
 import { GraphQLUpload, FileUpload } from 'graphql-upload';
 import Avatar from './avatar.entity';
@@ -10,16 +9,18 @@ export class AvatarResolver {
     async avatarUpload(
         @Args({ name: 'image', type: () => GraphQLUpload }) image: FileUpload
     ): Promise<boolean> {
-        const fileDir = process.env.NODE_ENV !== 'test' ? 'uploads' : 'testUploads';
-        const filePath = `${__dirname}/../../../${fileDir}`;
-        if (!fs.existsSync(filePath)) {
-            fs.mkdirSync(filePath);
-        }
+        // For time being, do nothing with the data 'chunk'.
+        // Eventually, this function will be replaced with the cloudinary upload_stream API
+        const nullStream = new Writable({
+            write(chunk, _, cb) {
+                cb();
+            }
+        });
 
         return new Promise((resolve, reject) => {
             image
                 .createReadStream()
-                .pipe(createWriteStream(`${filePath}/${image.filename}`))
+                .pipe(nullStream)
                 .on('finish', () => resolve(true))
                 .on('error', () => reject(false));
         });

--- a/packages/api/test/avatar.e2e-spec.ts
+++ b/packages/api/test/avatar.e2e-spec.ts
@@ -4,8 +4,6 @@ import { AppModule } from '../src/app.module';
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 
-const testUploadDir = `${__dirname}/../testUploads`;
-
 function generateVariableMap(keyName: string) {
     return {
         keyName: [`variables.${keyName}`]
@@ -35,10 +33,6 @@ describe('Avatar resolver (e2e)', () => {
         await app.init();
     });
 
-    afterAll(() => {
-        fs.rmdirSync(testUploadDir, { recursive: true });
-    });
-
     describe('upload avatar mutation', () => {
         it('uploads png image', () => {
             const testFile = `${__dirname}/../avatars/default/avatar.png`;
@@ -54,7 +48,10 @@ describe('Avatar resolver (e2e)', () => {
                 .set('Content-Type', 'multipart/form-data')
                 .field(constants.OPERATIONS, JSON.stringify({ query: AvatarUploadOp, variables }))
                 .field(constants.MAP, JSON.stringify(variableMap))
-                .attach(Object.keys(variableMap)[0], testFile);
+                .attach(Object.keys(variableMap)[0], testFile)
+                .expect((res) => {
+                    expect(res.body.data.avatarUpload).toBe(true);
+                });
         });
     });
 });

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -8,7 +8,7 @@ import {
     useQueryCache
 } from 'react-query';
 import { ReactQueryDevtools } from 'react-query-devtools';
-import { makeGraphQLQuery, makeGraphQLMutation } from './dataservice';
+import { makeGraphQLQuery, makeGraphQLMutation, makeGraphQLFileUpload } from './dataservice';
 import secureLogo from './assets/secure.svg';
 import innovativeLogo from './assets/innovative.svg';
 import { Button, InputField } from './components/common';
@@ -400,6 +400,24 @@ function FileUpload(): JSX.Element {
         }
     };
 
+    const handleFileUpload = (e: React.MouseEvent) => {
+        const AvatarUploadOp = `
+mutation AvatarUpload ($image: Upload!) {
+    avatarUpload(image: $image)
+}
+`;
+        const variables = { image: null, operationName: 'UploadAvatar' };
+
+        // update to use the useMutation hook from react-query
+        makeGraphQLFileUpload({ query: AvatarUploadOp, variables }, image as File).then(
+            ({ data }) => {
+                if (data.avatarUpload) {
+                    clearFile();
+                }
+            }
+        );
+    };
+
     const processFile = (file: File): void => {
         if (file.type === 'image/png') {
             setImage(file);
@@ -429,7 +447,9 @@ function FileUpload(): JSX.Element {
     return (
         <div className="text-gray-700">
             <h3 className="text-center text-2xl mb-2">Upload Image</h3>
-            <p className="italic text-center mb-2">Note: No API support yet...</p>
+            <p className="italic text-center mb-2">
+                Note: Currently, the API drops this on the floor...
+            </p>
             {!image && (
                 <div>
                     <div
@@ -479,7 +499,12 @@ function FileUpload(): JSX.Element {
                         <Button className="my-4 mr-6" variant="secondary" clickAction={clearFile}>
                             Cancel
                         </Button>
-                        <Button type="button" className="my-4" variant="primary">
+                        <Button
+                            type="button"
+                            className="my-4"
+                            variant="primary"
+                            clickAction={handleFileUpload}
+                        >
                             Upload
                         </Button>
                     </div>

--- a/packages/app/src/dataservice.ts
+++ b/packages/app/src/dataservice.ts
@@ -33,3 +33,30 @@ export const makeGraphQLMutation: MutationFunction<GraphQLResponse, QueryPayload
         body: JSON.stringify({ query, variables })
     }).then((res) => res.json());
 };
+
+export function makeGraphQLFileUpload({ query, variables = {} }: QueryPayload, file: File) {
+    const data = new FormData();
+
+    if (Object.keys(variables).length > 0) {
+        data.append(
+            'operations',
+            JSON.stringify({
+                query,
+                variables
+            })
+        );
+
+        data.append(
+            'map',
+            JSON.stringify({
+                '0': [`variables.${Object.keys(variables)[0]}`]
+            })
+        );
+        data.append('0', file as Blob);
+    }
+
+    return fetch(graphqlEndpoint, {
+        method: 'POST',
+        body: data
+    }).then((res) => res.json());
+}


### PR DESCRIPTION
Integrate the avatar file upload client-side component with the API.

Currently, the API simply "drops" the file on the virtual floor--basically does nothing.  This behavior will likely be updated to upload the avatar to cloudinary for asset management.