### PR TITLE
Handle JsonWebTokenError and add E2E tests 

### DIFF
--- a/packages/api/src/modules/auth/auth.resolver.ts
+++ b/packages/api/src/modules/auth/auth.resolver.ts
@@ -47,7 +47,7 @@ export class AuthResolver {
             try {
                 payload = this.authService.verifyToken(req.cookies.qid);
             } catch (error) {
-                if (error.name === 'TokenExpiredError') {
+                if (error.name === 'TokenExpiredError' || error.name === 'JsonWebTokenError') {
                     res.clearCookie('qid');
                 }
                 return {


### PR DESCRIPTION
This PR handles a "JsonWebTokenError" to clear the cookie for the refresh token, similar to the approach for a "TokenExpiredError".  It also adds E2E tests for the `refreshAccessToken` mutation.