### PR TITLE
Change refreshAccessToken mutation to be a query

### DIFF
--- a/packages/api/src/modules/auth/__tests__/auth.resolver.spec.ts
+++ b/packages/api/src/modules/auth/__tests__/auth.resolver.spec.ts
@@ -90,7 +90,7 @@ describe('Auth resolver', () => {
         });
     });
 
-    describe('refreshAccessToken mutation', () => {
+    describe('refreshAccessToken query', () => {
         it('refreshes the access token when presented with a valid refresh token', async () => {
             const res = {} as Response;
             res.cookie = jest.fn();

--- a/packages/api/src/modules/auth/auth.resolver.ts
+++ b/packages/api/src/modules/auth/auth.resolver.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import { UnauthorizedException } from '@nestjs/common';
-import { Args, Context, Field, Mutation, ObjectType, Resolver } from '@nestjs/graphql';
+import { Args, Context, Field, Mutation, ObjectType, Query, Resolver } from '@nestjs/graphql';
 import { AuthService } from './auth.service';
 import { UserService } from '../user/user.service';
 
@@ -38,7 +38,7 @@ export class AuthResolver {
         };
     }
 
-    @Mutation(() => LoginResponse)
+    @Query(() => LoginResponse)
     async refreshAccessToken(@Context() { req, res }: GraphQLContext): Promise<LoginResponse> {
         const refreshToken = req.cookies['qid'];
         if (refreshToken) {

--- a/packages/api/test/auth.e2e-spec.ts
+++ b/packages/api/test/auth.e2e-spec.ts
@@ -15,15 +15,15 @@ const oliver: CreateUserDto = {
     password: '123456'
 };
 
-const LoginOp = `
+const loginOp = `
 mutation Login($email: String!, $password: String!) {
     login(email: $email, password: $password) {
         accessToken
     }
 }`;
 
-const RefreshAccessTokenOp = `
-mutation RefreshAccessToken {
+const refreshAccessTokenQuery = `
+query {
     refreshAccessToken {
         accessToken
     }
@@ -54,7 +54,7 @@ describe('Auth resolver (e2e)', () => {
                 .post('/graphql')
                 .set('Content-Type', 'application/json')
                 .send({
-                    query: LoginOp,
+                    query: loginOp,
                     variables: { email: oliver.email, password: oliver.password }
                 })
                 .expect(({ body }) => {
@@ -70,7 +70,7 @@ describe('Auth resolver (e2e)', () => {
                 .post('/graphql')
                 .set('Content-Type', 'application/json')
                 .send({
-                    query: LoginOp,
+                    query: loginOp,
                     variables: { email: 'unknown-email@qc.com', password: oliver.password }
                 })
                 .expect(({ body }) => {
@@ -87,7 +87,7 @@ describe('Auth resolver (e2e)', () => {
                 .post('/graphql')
                 .set('Content-Type', 'application/json')
                 .send({
-                    query: LoginOp,
+                    query: loginOp,
                     variables: { email: oliver.email, password: 'wrong-password' }
                 })
                 .expect(({ body }) => {
@@ -109,7 +109,7 @@ describe('Auth resolver (e2e)', () => {
                 .set('Content-Type', 'application/json')
                 .set('Cookie', [`qid=${refreshToken}`])
                 .send({
-                    query: RefreshAccessTokenOp,
+                    query: refreshAccessTokenQuery,
                     variables: {}
                 })
                 .expect(({ body }) => {
@@ -124,7 +124,7 @@ describe('Auth resolver (e2e)', () => {
                 .post('/graphql')
                 .set('Content-Type', 'application/json')
                 .send({
-                    query: RefreshAccessTokenOp,
+                    query: refreshAccessTokenQuery,
                     variables: {}
                 })
                 .expect(({ body }) => {
@@ -148,7 +148,7 @@ describe('Auth resolver (e2e)', () => {
                 .set('Content-Type', 'application/json')
                 .set('Cookie', [`qid=${refreshToken}`])
                 .send({
-                    query: RefreshAccessTokenOp,
+                    query: refreshAccessTokenQuery,
                     variables: {}
                 })
                 .expect(({ body }) => {
@@ -170,7 +170,7 @@ describe('Auth resolver (e2e)', () => {
                 .set('Content-Type', 'application/json')
                 .set('Cookie', [`qid=${refreshToken}`])
                 .send({
-                    query: RefreshAccessTokenOp,
+                    query: refreshAccessTokenQuery,
                     variables: {}
                 })
                 .expect(({ body }) => {


### PR DESCRIPTION
Simple change to refactor the `refreshAccessToken` mutation to be a graphql query.