### PR TITLE
Persist 'login' after page refresh

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -8,17 +8,26 @@ import { makeGraphQLQuery } from './dataservice';
 jest.mock('./dataservice');
 
 test('renders hello react text', async () => {
-    mocked(makeGraphQLQuery).mockImplementation(() =>
-        Promise.resolve({ data: { status: 'Test is working!' } })
-    );
+    // This is a working example of returning different payloads based on the
+    // calling arguments (query keys)
+    mocked(makeGraphQLQuery).mockImplementation(({ queryKey }) => {
+        if (queryKey.length && queryKey[0] === 'status') {
+            return Promise.resolve({ data: { status: 'Test is working!' } });
+        }
+
+        return Promise.resolve({
+            data: { refreshAccessToken: { accessToken: null } }
+        });
+    });
 
     const { getByText } = render(<App />);
     const textElement = await waitFor(() => getByText(/orion labs side project/i));
     expect(textElement).toBeInTheDocument();
 });
 
+// TODO: move this to 'ServerStatus' component
 test(`renders 'All Good!'' when graphql call is successful`, async () => {
-    mocked(makeGraphQLQuery).mockImplementation(() =>
+    mocked(makeGraphQLQuery).mockImplementationOnce(() =>
         Promise.resolve({ data: { status: 'Mock is working!' } })
     );
 
@@ -27,8 +36,9 @@ test(`renders 'All Good!'' when graphql call is successful`, async () => {
     expect(textElement).toBeInTheDocument();
 });
 
+// TODO: move this to 'ServerStatus' component
 test(`renders 'Ah snap!'' when something is wrong with graphql call`, async () => {
-    mocked(makeGraphQLQuery).mockImplementation(() =>
+    mocked(makeGraphQLQuery).mockImplementationOnce(() =>
         Promise.resolve({ errors: { message: 'Something went wrong.' } })
     );
 

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -13,8 +13,8 @@ const queryClient = new QueryClient();
 function App(): JSX.Element {
     return (
         <BrowserRouter>
-            <Layout>
-                <QueryClientProvider client={queryClient}>
+            <QueryClientProvider client={queryClient}>
+                <Layout>
                     <Switch>
                         <Route exact path="/">
                             <Home />
@@ -30,8 +30,8 @@ function App(): JSX.Element {
                         </Route>
                     </Switch>
                     <ReactQueryDevtools initialIsOpen={false} />
-                </QueryClientProvider>
-            </Layout>
+                </Layout>
+            </QueryClientProvider>
         </BrowserRouter>
     );
 }

--- a/packages/app/src/components/LoginForm/index.tsx
+++ b/packages/app/src/components/LoginForm/index.tsx
@@ -14,7 +14,7 @@ mutation Login($email: String!, $password: String!) {
 
 function LoginForm(): JSX.Element {
     const [authError, setAuthError] = useState('');
-    const { token, login } = useAuthContext();
+    const { login } = useAuthContext();
 
     const [formValues, setFormValues] = useState({
         email: '',

--- a/packages/app/src/components/Nav/index.tsx
+++ b/packages/app/src/components/Nav/index.tsx
@@ -6,8 +6,7 @@ import NavLogo from './NavLogo';
 function Nav(): JSX.Element {
     const [isMobileLinksOpen, setIsMobileLinksOpen] = useState(false);
 
-    const isFetching = false;
-    const { token, logout } = useAuthContext();
+    const { token, isFetchingToken, logout } = useAuthContext();
 
     return (
         <header className="px-8 py-4 bg-purple-900 text-gray-400">
@@ -48,7 +47,7 @@ function Nav(): JSX.Element {
                     </button>
                     {/* The nav links that are displayed on larger screens */}
                     <div className="hidden sm:block flex items-center text-xl">
-                        {!isFetching && !token && (
+                        {!isFetchingToken && !token && (
                             <>
                                 <NavLink
                                     to="/login"
@@ -70,7 +69,7 @@ function Nav(): JSX.Element {
                             </>
                         )}
 
-                        {!isFetching && token && (
+                        {!isFetchingToken && token && (
                             <button
                                 type="button"
                                 className="px-2 py-1 hover:text-white focus:text-white"
@@ -84,7 +83,7 @@ function Nav(): JSX.Element {
                 </div>
                 {/* The nav links on small screens that are displayed when the button is clicked */}
                 <div className={`${isMobileLinksOpen ? 'block' : 'hidden'} mt-4 -ml-2 sm:hidden`}>
-                    {!isFetching && !token && (
+                    {!isFetchingToken && !token && (
                         <>
                             <NavLink
                                 to="/login"
@@ -102,7 +101,7 @@ function Nav(): JSX.Element {
                             </NavLink>
                         </>
                     )}
-                    {!isFetching && token && (
+                    {!isFetchingToken && token && (
                         <button
                             type="button"
                             className="w-full text-left px-2 py-1 mt-1 font-semibold rounded focus:bg-purple-800 hover:text-gray-100"

--- a/packages/app/src/context/AuthContext/index.tsx
+++ b/packages/app/src/context/AuthContext/index.tsx
@@ -1,7 +1,18 @@
 import React, { useState, useContext } from 'react';
+import { useQuery } from 'react-query';
+import { makeGraphQLQuery } from '../../dataservice';
+
+const refreshAccessTokenQuery = `
+query {
+    refreshAccessToken {
+        accessToken
+    }
+}
+`;
 
 interface AuthContextProps {
     token: string;
+    isFetchingToken: boolean;
     login: (t: string) => void;
     logout: () => void;
 }
@@ -12,12 +23,31 @@ interface AuthProviderProps {
 
 const AuthContext = React.createContext<AuthContextProps>({
     token: '',
+    isFetchingToken: false,
     login: (t: string) => {},
     logout: () => {}
 });
 
 function AuthProvider({ children }: AuthProviderProps): JSX.Element {
     const [token, setToken] = useState<string>('');
+
+    const { isLoading: isFetchingToken } = useQuery(
+        ['refreshToken', { query: refreshAccessTokenQuery }],
+        makeGraphQLQuery,
+        {
+            refetchInterval: 1000 * 60 * 8, // refresh access token every 8 minutes
+            onSuccess: (response) => {
+                if (response) {
+                    const { accessToken } = response.data?.refreshAccessToken;
+                    if (accessToken) {
+                        console.log('[Auth] Updating access token');
+                        setToken(accessToken);
+                    }
+                }
+            }
+        }
+    );
+
     const login = (t: string) => {
         setToken(t);
     };
@@ -26,7 +56,11 @@ function AuthProvider({ children }: AuthProviderProps): JSX.Element {
         setToken('');
     };
 
-    return <AuthContext.Provider value={{ token, login, logout }}>{children}</AuthContext.Provider>;
+    return (
+        <AuthContext.Provider value={{ token, isFetchingToken, login, logout }}>
+            {children}
+        </AuthContext.Provider>
+    );
 }
 
 const useAuthContext = () => useContext(AuthContext);


### PR DESCRIPTION
This change will fetch a new access token with each page refresh which will persist the user's 'login' state, assuming, of course, the refresh token is still valid.

This change will also fetch a new access token (and refresh token) every 8 minutes to ensure a valid access token while the user is in the app.

Fixes #55 