### PR TITLE
Add auth middleware to API to process bearer token

### DIFF
--- a/packages/api/@types/express/index.d.ts
+++ b/packages/api/@types/express/index.d.ts
@@ -1,0 +1,9 @@
+import User from '../../src/modules/user/user.entity';
+
+declare global {
+    namespace Express {
+        interface Request {
+            user: User;
+        }
+    }
+}

--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -8,6 +8,7 @@ import { StatusModule } from './modules/status/status.module';
 import { UserModule } from './modules/user/user.module';
 import { AvatarModule } from './modules/avatar/avatar.module';
 import { AuthModule } from './modules/auth/auth.module';
+import { AuthMiddleware } from './common/auth.middleware';
 
 @Module({
     imports: [
@@ -31,7 +32,7 @@ import { AuthModule } from './modules/auth/auth.module';
 export class AppModule implements NestModule {
     configure(consumer: MiddlewareConsumer) {
         if (process.env.NODE_ENV === 'development') {
-            consumer.apply(LoggerMiddleware).forRoutes('*');
+            consumer.apply(AuthMiddleware, LoggerMiddleware).forRoutes('*');
         }
     }
 }

--- a/packages/api/src/common/auth.middleware.ts
+++ b/packages/api/src/common/auth.middleware.ts
@@ -1,0 +1,34 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import clc from 'cli-color';
+import { AuthService } from '../modules/auth/auth.service';
+import { UserService } from '../modules/user/user.service';
+
+@Injectable()
+export class AuthMiddleware implements NestMiddleware {
+    constructor(private authService: AuthService, private userService: UserService) {}
+
+    async use(req: Request, _: Response, next: NextFunction) {
+        if (Object.keys(req.body).length && req.body.operationName !== 'IntrospectionQuery') {
+            const authorizationHeader = req.headers.authorization;
+            if (authorizationHeader) {
+                try {
+                    const token = authorizationHeader.split(' ')[1];
+                    const decodedPayload = this.authService.verifyToken(token);
+                    const authUser = await this.userService.findByEmail(
+                        decodedPayload.email as string
+                    );
+
+                    if (authUser) {
+                        console.log('auth user: ', authUser);
+                        req.user = authUser;
+                    }
+                } catch (err) {
+                    // noop for any errors...
+                    console.error(clc.red('Auth middleware error: ', err.message));
+                }
+            }
+        }
+        next();
+    }
+}

--- a/packages/api/src/modules/auth/auth.module.ts
+++ b/packages/api/src/modules/auth/auth.module.ts
@@ -17,6 +17,7 @@ import { AuthService } from './auth.service';
             inject: [ConfigService]
         })
     ],
-    providers: [AuthService, AuthResolver]
+    providers: [AuthService, AuthResolver],
+    exports: [AuthService]
 })
 export class AuthModule {}

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -12,6 +12,12 @@
     "baseUrl": "./",
     "skipLibCheck": true,
     "incremental": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "typeRoots": [
+      "@types",
+      "./node_modules/@types",
+      "../../node_modules/@types"
+
+    ]
   }
 }


### PR DESCRIPTION
Add authentication middleware to API to process the bearer token included in the "Authorization" header.  

If the token is valid, the middleware will attach the authenticated user to the `user` property on the `Request`.  To enable the additional type on the Express `Request` object, we need to take advantage of _declaration merging_ by adding our own `@types` file at the root of the project and adjusting the `tsconfig.json` to reference that file as well.

Fixes #60 