### PR TITLE
Add logout mutation to API

### DIFF
--- a/packages/api/src/modules/auth/__tests__/auth.resolver.spec.ts
+++ b/packages/api/src/modules/auth/__tests__/auth.resolver.spec.ts
@@ -90,6 +90,31 @@ describe('Auth resolver', () => {
         });
     });
 
+    describe('logout mutation', () => {
+        it('clears the refresh token cookie (qid)', async () => {
+            const res = {} as Response;
+            res.cookie = jest.fn();
+            res.clearCookie = jest.fn();
+
+            const req = {} as Request;
+
+            const ollie = await userService.create(oliver);
+
+            jest.spyOn(authService, 'authenticateUser').mockResolvedValue(ollie);
+            jest.spyOn(authService, 'generateAccessToken').mockImplementation(() => fakeToken);
+
+            await authResolver.login(oliver.email, oliver.password, {
+                req,
+                res
+            });
+
+            const result = authResolver.logout({ req, res });
+
+            expect(result).toBe(true);
+            expect(res.clearCookie).toHaveBeenCalledWith('qid');
+        });
+    });
+
     describe('refreshAccessToken mutation', () => {
         it('refreshes the access token when presented with a valid refresh token', async () => {
             const res = {} as Response;

--- a/packages/api/src/modules/auth/auth.resolver.ts
+++ b/packages/api/src/modules/auth/auth.resolver.ts
@@ -38,6 +38,12 @@ export class AuthResolver {
         };
     }
 
+    @Mutation(() => Boolean)
+    logout(@Context() { res }: GraphQLContext): boolean {
+        res.clearCookie('qid');
+        return true;
+    }
+
     @Mutation(() => LoginResponse)
     async refreshAccessToken(@Context() { req, res }: GraphQLContext): Promise<LoginResponse> {
         const refreshToken = req.cookies['qid'];


### PR DESCRIPTION
Add simple `logout` mutation to API.  This mutation will clear the refresh token cookie from the client.

Fixes #63 