### PR TITLE
Add auth guard and protect 'users' query

### DIFF
--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -31,8 +31,10 @@ import { AuthMiddleware } from './common/auth.middleware';
 })
 export class AppModule implements NestModule {
     configure(consumer: MiddlewareConsumer) {
-        if (process.env.NODE_ENV === 'development') {
+        if (process.env.NODE_ENV !== 'test') {
             consumer.apply(AuthMiddleware, LoggerMiddleware).forRoutes('*');
+        } else {
+            consumer.apply(AuthMiddleware).forRoutes('*');
         }
     }
 }

--- a/packages/api/src/common/auth.middleware.ts
+++ b/packages/api/src/common/auth.middleware.ts
@@ -20,12 +20,13 @@ export class AuthMiddleware implements NestMiddleware {
                     );
 
                     if (authUser) {
-                        console.log('auth user: ', authUser);
                         req.user = authUser;
                     }
                 } catch (err) {
                     // noop for any errors...
-                    console.error(clc.red('Auth middleware error: ', err.message));
+                    if (process.env.NODE_ENV !== 'test') {
+                        console.log(clc.red('Auth middleware error: ', err.message));
+                    }
                 }
             }
         }

--- a/packages/api/src/modules/auth/auth.guard.ts
+++ b/packages/api/src/modules/auth/auth.guard.ts
@@ -1,0 +1,11 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+    canActivate(context: ExecutionContext): boolean {
+        const ctx = GqlExecutionContext.create(context);
+        const authUser = ctx.getContext().req.user;
+        return !!authUser;
+    }
+}

--- a/packages/api/src/modules/user/user.resolver.ts
+++ b/packages/api/src/modules/user/user.resolver.ts
@@ -1,3 +1,4 @@
+import { UseGuards } from '@nestjs/common';
 import {
     Query,
     Resolver,
@@ -8,6 +9,7 @@ import {
     ResolveField,
     Parent
 } from '@nestjs/graphql';
+import { AuthGuard } from '../auth/auth.guard';
 import { User } from './user.entity';
 import { UserService } from './user.service';
 
@@ -31,6 +33,7 @@ export class UserResolver {
     constructor(private readonly userService: UserService) {}
 
     @Query(() => [User], { name: 'users' })
+    @UseGuards(AuthGuard)
     getUsers(): Promise<User[]> {
         return this.userService.getAllUsers();
     }


### PR DESCRIPTION
Add auth guard to API to be able to protect any query/mutation from any user that is not authenticated.  As part of this PR, the `users` query is now protected with this auth guard.

Fixes #67 