### PR TITLE
Add <ProtectedRoute /> component

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -7,6 +7,7 @@ import UserRegisterPage from './containers/UserRegisterPage';
 import UserListPage from './containers/UserListPage';
 import Layout from './containers/Layout';
 import Home from './containers/Home';
+import ProtectedRoute from './components/ProtectedRoute';
 
 const queryClient = new QueryClient();
 
@@ -25,9 +26,9 @@ function App(): JSX.Element {
                         <Route exact path="/register">
                             <UserRegisterPage />
                         </Route>
-                        <Route exact path="/users">
+                        <ProtectedRoute exact path="/users">
                             <UserListPage />
-                        </Route>
+                        </ProtectedRoute>
                     </Switch>
                     <ReactQueryDevtools initialIsOpen={false} />
                 </Layout>

--- a/packages/app/src/components/LoginForm/index.tsx
+++ b/packages/app/src/components/LoginForm/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useMutation } from 'react-query';
+import { useHistory, useLocation } from 'react-router-dom';
 import { useAuthContext } from '../../context/AuthContext';
 import { makeGraphQLMutation } from '../../dataservice';
 import { Button, InputField } from '../common';
@@ -12,9 +13,17 @@ mutation Login($email: String!, $password: String!) {
 }
 `;
 
+interface LocationState {
+    from: { pathname: string };
+}
+
 function LoginForm(): JSX.Element {
+    const history = useHistory();
+    const location = useLocation<LocationState>();
     const [authError, setAuthError] = useState('');
     const { login } = useAuthContext();
+
+    const { from } = location.state || { from: { pathname: '/' } };
 
     const [formValues, setFormValues] = useState({
         email: '',
@@ -52,7 +61,9 @@ function LoginForm(): JSX.Element {
                         if (data) {
                             setAuthError('');
                             clearForm();
-                            login(data.login.accessToken);
+                            login(data.login.accessToken, () => {
+                                history.replace(from);
+                            });
                         }
 
                         if (errors?.length > 0) {

--- a/packages/app/src/components/ProtectedRoute/index.tsx
+++ b/packages/app/src/components/ProtectedRoute/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Redirect, Route, RouteProps } from 'react-router-dom';
+import { useAuthContext } from '../../context/AuthContext';
+
+function ProtectedRoute({ children, ...rest }: RouteProps): JSX.Element {
+    const authCtx = useAuthContext();
+    return (
+        <Route
+            {...rest}
+            render={({ location }) =>
+                authCtx.token ? (
+                    children
+                ) : (
+                    <Redirect to={{ pathname: '/login', state: { from: location } }} />
+                )
+            }
+        />
+    );
+}
+
+export default ProtectedRoute;

--- a/packages/app/src/components/ServerStatus/index.tsx
+++ b/packages/app/src/components/ServerStatus/index.tsx
@@ -15,7 +15,7 @@ function ServerStatus(): JSX.Element {
     return (
         <>
             {!isLoading && (
-                <div className="text-lg text-gray-600 border-2 border-gray-600 rounded-md py-2 text-center">
+                <div className="text-lg text-gray-600 border-2 border-gray-600 rounded-md py-2 px-4 text-center">
                     GraphQL server status:
                     <svg
                         className={`w-6 h-6 ml-2 inline-block stroke-current ${

--- a/packages/app/src/containers/Home/index.tsx
+++ b/packages/app/src/containers/Home/index.tsx
@@ -11,15 +11,14 @@ function Home(): JSX.Element {
                 <HeroBanner />
             </div>
 
-            <div className="mt-12 max-w-md mx-auto">
+            <div className="mt-12 mx-auto flex flex-col items-center">
                 <ServerStatus />
+                <div className="mt-10 text-lg text-gray-600 border-2 border-gray-600 rounded-md py-2 px-4 text-center">
+                    <Link to="/users">List Users</Link>
+                </div>
             </div>
 
             <Features />
-
-            <div className="mt-12 max-w-md mx-auto text-lg text-gray-600 border-2 border-gray-600 rounded-md py-2 text-center">
-                <Link to="/users">Show Users</Link>
-            </div>
         </>
     );
 }

--- a/packages/app/src/context/AuthContext/index.tsx
+++ b/packages/app/src/context/AuthContext/index.tsx
@@ -19,8 +19,8 @@ mutation Logout {
 interface AuthContextProps {
     token: string;
     isFetchingToken: boolean;
-    login: (t: string) => void;
-    logout: () => void;
+    login: (t: string, cb?: () => void) => void;
+    logout: (cb?: () => void) => void;
 }
 
 interface AuthProviderProps {
@@ -61,16 +61,28 @@ function AuthProvider({ children }: AuthProviderProps): JSX.Element {
         { executeImmediate: true }
     );
 
-    const login = (t: string) => {
+    const login = (t: string, cb?: () => void) => {
         setToken(t);
+        if (cb) {
+            cb();
+        }
     };
 
-    const logout = () => {
-        doLogout({
-            query: logoutOp,
-            variables: {}
-        });
-        setToken('');
+    const logout = (cb?: () => void) => {
+        doLogout(
+            {
+                query: logoutOp,
+                variables: {}
+            },
+            {
+                onSuccess: () => {
+                    setToken('');
+                    if (cb) {
+                        cb();
+                    }
+                }
+            }
+        );
     };
 
     return (


### PR DESCRIPTION
Add a `<ProtectedRoute />` component to the client app that will only route the user if they are authenticated.  Otherwise, it will redirect the user to the `/login` route.  There is also a bit of state that is maintained which will redirect the user back to the originally requested route after login.

Fixes #73 