### PR TITLE
Update access token on token refresh

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -10,7 +10,7 @@ jest.mock('./dataservice');
 test('renders hello react text', async () => {
     // This is a working example of returning different payloads based on the
     // calling arguments (query keys)
-    mocked(makeGraphQLQuery).mockImplementation(({ queryKey }) => {
+    mocked(makeGraphQLQuery).mockImplementationOnce(({ queryKey }) => {
         if (queryKey.length && queryKey[0] === 'status') {
             return Promise.resolve({ data: { status: 'Test is working!' } });
         }
@@ -39,7 +39,7 @@ test(`renders 'All Good!'' when graphql call is successful`, async () => {
 // TODO: move this to 'ServerStatus' component
 test(`renders 'Ah snap!'' when something is wrong with graphql call`, async () => {
     mocked(makeGraphQLQuery).mockImplementationOnce(() =>
-        Promise.resolve({ errors: { message: 'Something went wrong.' } })
+        Promise.resolve({ errors: [{ message: 'Something went wrong.' }] })
     );
 
     const { getByText } = render(<App />);

--- a/packages/app/src/context/AuthContext/index.tsx
+++ b/packages/app/src/context/AuthContext/index.tsx
@@ -41,9 +41,11 @@ function AuthProvider({ children }: AuthProviderProps): JSX.Element {
     const { mutate: doLogout } = useMutation(makeGraphQLMutation);
 
     const handleRefreshSuccess = (response: GraphQLResponse) => {
-        const { accessToken } = response.data?.refreshAccessToken;
-        if (accessToken) {
-            setToken(accessToken);
+        if (response) {
+            const { accessToken } = response.data?.refreshAccessToken;
+            if (accessToken) {
+                setToken(accessToken);
+            }
         }
     };
 


### PR DESCRIPTION
Fix issue where the access token was not updating on a "token refresh".  It was initially getting set correctly, but not after any "token refresh" action, thus remained stale.

This PR fixes the issue by moving the `onSuccess` callback to the `mutate` function, vice defining it with the `useMutation` hook.  Not completely sure why this is different, but it does solve the problem.

Fixes #76 