### PR TITLE
Add 'me' query

### DIFF
--- a/packages/api/src/modules/user/__tests__/user.resolver.spec.ts
+++ b/packages/api/src/modules/user/__tests__/user.resolver.spec.ts
@@ -1,3 +1,4 @@
+import { Request, Response } from 'express';
 import { Test } from '@nestjs/testing';
 import { UserService } from '../user.service';
 import { UserResolver } from '../user.resolver';
@@ -46,6 +47,32 @@ describe('User resolver', () => {
 
             expect(await userResolver.getUsers()).toBe(result);
             expect(getAllUsersSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('me query', () => {
+        it('returns null if user is not logged in', () => {
+            const req = {} as Request;
+            const res = {} as Response;
+            const result = userResolver.me({ req, res });
+            expect(result).toBeNull();
+        });
+
+        it('returns the currently logged in user', () => {
+            const ollie = {
+                id: '05fc4d47-b88c-4494-86e9-b64d748e1df6',
+                firstName: 'Ollie',
+                lastName: 'Queen',
+                email: 'oliver@qc.com',
+                displayName: 'Oliver Queen',
+                password: '123456',
+                refreshTokenId: 0
+            };
+            const req = {} as Request;
+            req.user = ollie;
+            const res = {} as Response;
+            const result = userResolver.me({ req, res });
+            expect(result).toBe(ollie);
         });
     });
 

--- a/packages/api/src/modules/user/user.resolver.ts
+++ b/packages/api/src/modules/user/user.resolver.ts
@@ -1,3 +1,4 @@
+import { Request, Response } from 'express';
 import { UseGuards } from '@nestjs/common';
 import {
     Query,
@@ -7,11 +8,17 @@ import {
     Mutation,
     Args,
     ResolveField,
-    Parent
+    Parent,
+    Context
 } from '@nestjs/graphql';
 import { AuthGuard } from '../auth/auth.guard';
 import { User } from './user.entity';
 import { UserService } from './user.service';
+
+interface GraphQLContext {
+    req: Request;
+    res: Response;
+}
 
 @InputType()
 class RegisterUserInput {
@@ -47,5 +54,13 @@ export class UserResolver {
     async registerUser(@Args('userData') userData: RegisterUserInput): Promise<User> {
         const newUser = await this.userService.create(userData);
         return newUser;
+    }
+
+    @Query(() => User, { nullable: true })
+    me(@Context() { req }: GraphQLContext): User | null {
+        if (req.user) {
+            return req.user;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Add `me` query to return the user info associated with the current authenticated user (based on JWT in `Authorization` header)

Fixes #52 