### PR TITLE
chore: consolidate tsconfigs and remove unused imports

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -1,4 +1,4 @@
-name: API tests
+name: API Verification Checks
 
 on:
     push:
@@ -15,7 +15,7 @@ on:
 
 jobs:
     runner-job:
-        name: API test
+        name: API Build and Tests
         runs-on: ubuntu-latest
 
         env:

--- a/.github/workflows/app-test.yml
+++ b/.github/workflows/app-test.yml
@@ -1,4 +1,4 @@
-name: App tests
+name: App Verification Checks
 
 on:
     push:
@@ -15,7 +15,7 @@ on:
 
 jobs:
     runner-job:
-        name: App test
+        name: App Build and Tests
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -1,4 +1,4 @@
-name: Shared lib tests
+name: Shared Lib Verification Checks
 
 on:
     push:
@@ -15,7 +15,7 @@ on:
 
 jobs:
     runner-job:
-        name: Shared lib test
+        name: Shared Lib Build and Tests
         runs-on: ubuntu-latest
 
         steps:

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,25 +1,20 @@
 {
-  "compilerOptions": {
-    "module": "commonjs",
-    "declaration": true,
-    "removeComments": true,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "allowSyntheticDefaultImports": true,
-    "target": "es2017",
-    "sourceMap": true,
-    "outDir": "./dist",
-    "baseUrl": "./",
-    "skipLibCheck": true,
-    "incremental": true,
-    "esModuleInterop": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "typeRoots": [
-      "@types",
-      "./node_modules/@types",
-      "../../node_modules/@types"
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "module": "commonjs",
+        "declaration": true,
+        "removeComments": true,
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "outDir": "./dist",
+        "baseUrl": "./",
+        "incremental": true,
+        "esModuleInterop": true,
+        "typeRoots": [
+          "@types",
+          "./node_modules/@types",
+          "../../node_modules/@types"
 
-    ]
-  }
+        ]
+      }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -24,6 +24,7 @@
         "tailwindcss": "2.2.8"
     },
     "scripts": {
+        "prebuild": "yarn build:css",
         "build": "react-scripts build",
         "build:css": "postcss src/styles/tailwind.css -o src/styles/main.css",
         "clean": "rm -rf build",

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { mocked } from 'ts-jest/utils';
 import '@testing-library/jest-dom/extend-expect';

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';

--- a/packages/app/src/components/Features/index.tsx
+++ b/packages/app/src/components/Features/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import secureLogo from '../../assets/secure.svg';
 import innovativeLogo from '../../assets/innovative.svg';
 

--- a/packages/app/src/components/FileUpload/index.tsx
+++ b/packages/app/src/components/FileUpload/index.tsx
@@ -20,10 +20,10 @@ function FileUpload(): JSX.Element {
         }
     });
 
-    const handleDragEnter: React.DragEventHandler<HTMLDivElement> = (e) => {
+    const handleDragEnter: React.DragEventHandler<HTMLDivElement> = () => {
         setHighlight(true);
     };
-    const handleDragLeave: React.DragEventHandler<HTMLDivElement> = (e) => {
+    const handleDragLeave: React.DragEventHandler<HTMLDivElement> = () => {
         setHighlight(false);
     };
     const handleDragOver: React.DragEventHandler<HTMLDivElement> = (e) => {
@@ -45,7 +45,7 @@ function FileUpload(): JSX.Element {
         }
     };
 
-    const handleFileUpload = (e: React.MouseEvent) => {
+    const handleFileUpload = () => {
         const variables = { image: null, operationName: 'UploadAvatar' };
 
         upload({ query: AvatarUploadOp, variables, file: image as File });

--- a/packages/app/src/components/Footer/About.tsx
+++ b/packages/app/src/components/Footer/About.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function About(): JSX.Element {
     return (
         <section className="max-w-none sm:max-w-md">

--- a/packages/app/src/components/Footer/Connect.tsx
+++ b/packages/app/src/components/Footer/Connect.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function Connect(): JSX.Element {
     return (
         <section className="sm:ml-6">

--- a/packages/app/src/components/Footer/__tests__/About.test.tsx
+++ b/packages/app/src/components/Footer/__tests__/About.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, cleanup } from '@testing-library/react';
 import About from '../About';
 

--- a/packages/app/src/components/Footer/__tests__/Connect.test.tsx
+++ b/packages/app/src/components/Footer/__tests__/Connect.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, cleanup } from '@testing-library/react';
 import Connect from '../Connect';
 

--- a/packages/app/src/components/Footer/__tests__/Footer.test.tsx
+++ b/packages/app/src/components/Footer/__tests__/Footer.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, cleanup } from '@testing-library/react';
 import Footer from '../';
 

--- a/packages/app/src/components/Footer/index.tsx
+++ b/packages/app/src/components/Footer/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import About from './About';
 import Connect from './Connect';
 

--- a/packages/app/src/components/HeroBanner/index.tsx
+++ b/packages/app/src/components/HeroBanner/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function HeroBanner(): JSX.Element {
     return (
         <div

--- a/packages/app/src/components/Nav/NavLogo.tsx
+++ b/packages/app/src/components/Nav/NavLogo.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function NavLogo(): JSX.Element {
     return (
         <div className="flex flex-col items-end">

--- a/packages/app/src/components/Nav/index.tsx
+++ b/packages/app/src/components/Nav/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import { useAuthContext } from '../../context/AuthContext';
 import NavLogo from './NavLogo';

--- a/packages/app/src/components/Nav/index.tsx
+++ b/packages/app/src/components/Nav/index.tsx
@@ -46,7 +46,7 @@ function Nav(): JSX.Element {
                         </svg>
                     </button>
                     {/* The nav links that are displayed on larger screens */}
-                    <div className="hidden sm:block flex items-center text-xl">
+                    <div className="hidden sm:block items-center text-xl">
                         {!isFetchingToken && !token && (
                             <>
                                 <NavLink

--- a/packages/app/src/components/ProtectedRoute/index.tsx
+++ b/packages/app/src/components/ProtectedRoute/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Redirect, Route, RouteProps } from 'react-router-dom';
 import { useAuthContext } from '../../context/AuthContext';
 

--- a/packages/app/src/components/ServerStatus/index.tsx
+++ b/packages/app/src/components/ServerStatus/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import useServerStatus from '../../hooks/useServerStatus';
 import Spinner from '../Spinner';
 

--- a/packages/app/src/components/Spinner/index.tsx
+++ b/packages/app/src/components/Spinner/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function Spinner(): JSX.Element {
     return (
         <div className="fixed top-0 right-0 h-screen w-screen z-50 flex justify-center items-center">

--- a/packages/app/src/components/UserCards/index.tsx
+++ b/packages/app/src/components/UserCards/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { User } from '../../types';
 
 type UserCardProps = { user: User };

--- a/packages/app/src/components/UserList/index.tsx
+++ b/packages/app/src/components/UserList/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { User } from '../../types';
 
 type UserRecordProps = { className?: string; user: User };

--- a/packages/app/src/components/common/Button/Button.test.tsx
+++ b/packages/app/src/components/common/Button/Button.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import user from '@testing-library/user-event';
 import Button from './Button';

--- a/packages/app/src/components/common/InputField/InputField.test.tsx
+++ b/packages/app/src/components/common/InputField/InputField.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, cleanup } from '@testing-library/react';
 import user from '@testing-library/user-event';
 import InputField from './InputField';

--- a/packages/app/src/components/common/Toggle/Toggle.test.tsx
+++ b/packages/app/src/components/common/Toggle/Toggle.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, cleanup } from '@testing-library/react';
 import user from '@testing-library/user-event';
 import Toggle from './Toggle';

--- a/packages/app/src/containers/Home/index.tsx
+++ b/packages/app/src/containers/Home/index.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import { Link } from 'react-router-dom';
-import Features from '../../components/Features/indes';
+import Features from '../../components/Features';
 import HeroBanner from '../../components/HeroBanner';
 import ServerStatus from '../../components/ServerStatus';
 import { useAuthContext } from '../../context/AuthContext';

--- a/packages/app/src/containers/LoginPage/index.tsx
+++ b/packages/app/src/containers/LoginPage/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Redirect } from 'react-router-dom';
 import LoginForm from '../../components/LoginForm';
 import { useAuthContext } from '../../context/AuthContext';

--- a/packages/app/src/containers/UserListPage/index.tsx
+++ b/packages/app/src/containers/UserListPage/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import FileUpload from '../../components/FileUpload';
 import Spinner from '../../components/Spinner';
 import UserCards from '../../components/UserCards';

--- a/packages/app/src/containers/UserRegisterPage/index.tsx
+++ b/packages/app/src/containers/UserRegisterPage/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useHistory } from 'react-router-dom';
 import UserRegisterForm from '../../components/UserRegisterForm';
 

--- a/packages/app/src/context/AuthContext/index.tsx
+++ b/packages/app/src/context/AuthContext/index.tsx
@@ -31,7 +31,7 @@ interface AuthProviderProps {
 const AuthContext = React.createContext<AuthContextProps>({
     token: '',
     isFetchingToken: true,
-    login: (t: string) => {},
+    login: () => {},
     logout: () => {}
 });
 

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -1,26 +1,22 @@
 {
-  "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "noFallthroughCasesInSwitch": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx"
-  },
-  "include": [
-    "src"
-  ]
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "lib": [
+          "dom",
+          "dom.iterable",
+          "esnext"
+        ],
+        "allowJs": true,
+        "esModuleInterop": true,
+        "strict": true,
+        "forceConsistentCasingInFileNames": true,
+        "module": "esnext",
+        "moduleResolution": "node",
+        "isolatedModules": true,
+        "noEmit": true,
+        "jsx": "react-jsx"
+    },
+    "include": [
+      "src"
+    ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "es2017",
+        "skipLibCheck": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "allowSyntheticDefaultImports": true,
+        "resolveJsonModule": true,
+        "noFallthroughCasesInSwitch": true,
+        "sourceMap": true,
+    }
+}


### PR DESCRIPTION
Add top level `tsconfig.json` to consolidate compiler options and remove all unused imports and variables in the client side app.

Fixes #106 