### PR TITLE
Tweak User page

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import LoginPage from './containers/LoginPage';
 import UserRegisterPage from './containers/UserRegisterPage';
-import UserListPage from './containers/UserListPage';
+import UserPage from './containers/UserPage';
 import Layout from './containers/Layout';
 import Home from './containers/Home';
 import ProtectedRoute from './components/ProtectedRoute';
@@ -26,7 +26,7 @@ function App(): JSX.Element {
                             <UserRegisterPage />
                         </Route>
                         <ProtectedRoute exact path="/users">
-                            <UserListPage />
+                            <UserPage />
                         </ProtectedRoute>
                     </Switch>
                     <ReactQueryDevtools initialIsOpen={false} />

--- a/packages/app/src/components/ProtectedRoute/index.tsx
+++ b/packages/app/src/components/ProtectedRoute/index.tsx
@@ -1,8 +1,17 @@
 import { Redirect, Route, RouteProps } from 'react-router-dom';
 import { useAuthContext } from '../../context/AuthContext';
+import Spinner from '../Spinner';
 
 function ProtectedRoute({ children, ...rest }: RouteProps): JSX.Element {
     const authCtx = useAuthContext();
+    const hasToken = localStorage.getItem('hasToken') === 'true';
+
+    // If we know we have a token, let's show the spinner until we can
+    // fetch a new access token
+    if (hasToken && !authCtx.token) {
+        return <Spinner />;
+    }
+
     return (
         <Route
             {...rest}

--- a/packages/app/src/containers/UserPage/index.tsx
+++ b/packages/app/src/containers/UserPage/index.tsx
@@ -4,7 +4,7 @@ import UserCards from '../../components/UserCards';
 import UserList from '../../components/UserList';
 import useUsers from '../../hooks/useUsers';
 
-function UserListPage(): JSX.Element {
+function UserPage(): JSX.Element {
     const { data: response, isLoading } = useUsers();
 
     if (isLoading) return <Spinner />;
@@ -20,4 +20,4 @@ function UserListPage(): JSX.Element {
     );
 }
 
-export default UserListPage;
+export default UserPage;

--- a/packages/app/src/containers/UserPage/index.tsx
+++ b/packages/app/src/containers/UserPage/index.tsx
@@ -1,18 +1,49 @@
+import { useState } from 'react';
+import { Button } from '../../components/common';
 import FileUpload from '../../components/FileUpload';
 import Spinner from '../../components/Spinner';
 import UserCards from '../../components/UserCards';
 import UserList from '../../components/UserList';
+import useQueryParams from '../../hooks/useQueryParams';
 import useUsers from '../../hooks/useUsers';
 
+enum VIEW {
+    List = 'list',
+    Cards = 'cards'
+}
+
 function UserPage(): JSX.Element {
+    const query = useQueryParams();
+    const [view, setView] = useState(query.get('view') || VIEW.Cards);
     const { data: response, isLoading } = useUsers();
 
     if (isLoading) return <Spinner />;
 
     return (
         <div className="w-full md:w-3/4 mx-auto mt-12 px-4">
-            <UserList users={response?.data.users} />
-            <UserCards className="mt-24" users={response?.data.users} />
+            <div className="flex justify-center gap-x-4">
+                <Button
+                    type="button"
+                    className="w-32 my-4"
+                    variant={view === VIEW.List ? 'primary' : 'secondary'}
+                    clickAction={() => setView(VIEW.List)}
+                >
+                    List
+                </Button>
+                <Button
+                    type="button"
+                    className="w-32 my-4"
+                    variant={view === VIEW.Cards ? 'primary' : 'secondary'}
+                    clickAction={() => setView(VIEW.Cards)}
+                >
+                    Cards
+                </Button>
+            </div>
+            {view === VIEW.List ? (
+                <UserList className="mt-16" users={response?.data.users} />
+            ) : (
+                <UserCards className="mt-16" users={response?.data.users} />
+            )}
             <div className="mt-24 mb-4 mx-auto max-w-md">
                 <FileUpload />
             </div>

--- a/packages/app/src/context/AuthContext/index.tsx
+++ b/packages/app/src/context/AuthContext/index.tsx
@@ -50,6 +50,8 @@ function AuthProvider({ children }: AuthProviderProps): JSX.Element {
             const { accessToken } = response.data?.refreshAccessToken;
             if (accessToken) {
                 setToken(accessToken);
+            } else {
+                localStorage.removeItem('hasToken');
             }
         }
     };

--- a/packages/app/src/context/AuthContext/index.tsx
+++ b/packages/app/src/context/AuthContext/index.tsx
@@ -75,6 +75,7 @@ function AuthProvider({ children }: AuthProviderProps): JSX.Element {
     );
 
     const login = (t: string, cb?: () => void) => {
+        localStorage.setItem('hasToken', 'true');
         setToken(t);
         if (cb) {
             cb();
@@ -86,6 +87,7 @@ function AuthProvider({ children }: AuthProviderProps): JSX.Element {
             query: logoutOp,
             variables: {}
         });
+        localStorage.removeItem('hasToken');
     };
 
     return (

--- a/packages/app/src/hooks/useQueryParams.tsx
+++ b/packages/app/src/hooks/useQueryParams.tsx
@@ -1,0 +1,5 @@
+import { useLocation } from 'react-router-dom';
+
+export default function useQueryParams() {
+    return new URLSearchParams(useLocation().search);
+}


### PR DESCRIPTION
This PR tweaks the user page (renamed) a bit to toggle the view between a list view and a card view.  It also updates the `ProtectedRoute` cmp to wait for the access token if the user hits the route via the url vice in-app navigation.  This change prevents the unnecessary redirect to the login page, since the user is logged in, we just don't have the in-memory token yet.