### PR TITLE
Move user seed logic to lifecycle method

### DIFF
--- a/packages/api/src/user/user.module.ts
+++ b/packages/api/src/user/user.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, OnModuleInit } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserResolver } from './user.resolver';
 import { Logger } from '@nestjs/common';
@@ -14,17 +14,18 @@ const seedUser = {
     providers: [UserResolver, UserService],
     exports: [UserService]
 })
-export class UserModule {
+export class UserModule implements OnModuleInit {
     private readonly logger = new Logger(UserModule.name);
 
-    constructor(private userService: UserService) {
-        if (process.env.NODE_ENV !== 'test') {
-            this.userService.getAllUsers().then((users) => {
-                if (users.length === 0) {
-                    this.logger.log(`Creating seed user: ${seedUser.email} / ${seedUser.password}`);
-                    userService.create(seedUser);
-                }
-            });
+    constructor(private userService: UserService) {}
+
+    async onModuleInit() {
+        if (process.env.NODE_ENV === 'development') {
+            const users = await this.userService.getAllUsers();
+            if (users.length === 0) {
+                this.logger.log(`Creating seed user: ${seedUser.email} / ${seedUser.password}`);
+                await this.userService.create(seedUser);
+            }
         }
     }
 }


### PR DESCRIPTION
Make use of the built-in Nestjs lifecycle methods as a trigger to seed the initial user on API start up.