### PR TITLE
Encapsulate mobile menu button and icon

### DIFF
--- a/packages/app/src/components/Nav/MobileMenuButton.tsx
+++ b/packages/app/src/components/Nav/MobileMenuButton.tsx
@@ -1,0 +1,20 @@
+import MobileMenuIcon from './MobileMenuIcon';
+
+interface Props {
+    isTriggered: boolean;
+    clickAction: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+}
+
+function MobileMenuButton({isTriggered, clickAction}: Props): JSX.Element {
+    return (
+        <button
+            className="focus:text-gray-100 focus:outline-none hover:text-gray-100 sm:hidden"
+            type="button"
+            onClick={clickAction}
+        >
+            <MobileMenuIcon isOpen={isTriggered} />
+        </button>
+    );
+}
+
+export default MobileMenuButton;

--- a/packages/app/src/components/Nav/MobileMenuIcon.tsx
+++ b/packages/app/src/components/Nav/MobileMenuIcon.tsx
@@ -1,0 +1,36 @@
+function CloseIcon(): JSX.Element {
+    return (
+        <path
+            fillRule="evenodd"
+            d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+            clipRule="evenodd"
+            data-testid="close-icon"
+        ></path>
+    );
+}
+
+function MenuIcon(): JSX.Element {
+    return (
+        <path
+            fillRule="evenodd"
+            d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
+            clipRule="evenodd"
+            data-testid="menu-icon"
+        ></path>
+    );
+}
+
+interface Props {
+    isOpen: boolean;
+}
+
+function MobileMenuIcon({ isOpen }: Props): JSX.Element {
+    return (
+        <svg  viewBox="0 0 20 20" fill="currentColor" className="w-8 h-8 fill-current">
+            <title>{`${isOpen ? "Close" : "Open Menu"}`}</title>
+            {isOpen ? <CloseIcon /> : <MenuIcon />}
+        </svg>
+    );
+}
+
+export default MobileMenuIcon;

--- a/packages/app/src/components/Nav/__tests__/MobileMenuButton.test.tsx
+++ b/packages/app/src/components/Nav/__tests__/MobileMenuButton.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import user from '@testing-library/user-event';
+import MobileMenuButton from '../MobileMenuButton';
+
+describe('MobileMenuButton component', () => {
+    it('renders a <button>', () => {
+        render(
+            <MobileMenuButton
+                isTriggered={false}
+                clickAction={() => {
+                    /* empty */
+                }}
+            />
+        );
+        expect(screen.getByRole('button')).toBeDefined();
+    });
+
+    it('fires click handler when clicked', () => {
+        const handler = jest.fn();
+        render(<MobileMenuButton isTriggered={false} clickAction={handler} />);
+        const button = screen.getByRole('button');
+        user.click(button);
+        expect(handler).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/app/src/components/Nav/__tests__/MobileMenuIcon.test.tsx
+++ b/packages/app/src/components/Nav/__tests__/MobileMenuIcon.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import MobileMenuIcon from '../MobileMenuIcon';
+
+describe('MobileMenuIcon component', () => {
+    it('renders a single <svg>', () => {
+        // utilizing 'container' to get <svg> since the <svg> does not
+        // have a default aria role so unable to 'getByRole()'
+        const { container } = render(<MobileMenuIcon isOpen={false} />);
+        expect(container.querySelectorAll('svg')).toHaveLength(1);
+    });
+
+    it('renders the menu icon when menu is closed', () => {
+        render(<MobileMenuIcon isOpen={false} />);
+        expect(screen.getByTestId('menu-icon')).toBeDefined();
+    });
+
+    it('renders the close icon when menu is open', () => {
+        render(<MobileMenuIcon isOpen={true} />);
+        expect(screen.getByTestId('close-icon')).toBeDefined();
+    });
+
+    it('does not render the menu icon when menu is open', () => {
+        render(<MobileMenuIcon isOpen={true} />);
+        expect(screen.queryByTestId('menu-icon')).toBeNull();
+    });
+
+    it('does not render the close icon when menu is closed', () => {
+        render(<MobileMenuIcon isOpen={false} />);
+        expect(screen.queryByTestId('close-icon')).toBeNull();
+    });
+
+    it('displays "Open Menu" as title when menu is closed', () => {
+        render(<MobileMenuIcon isOpen={false} />);
+        expect(screen.getByTitle('Open Menu')).toBeDefined();
+    });
+
+    it('displays "Close" as title when menu is open', () => {
+        render(<MobileMenuIcon isOpen={true} />);
+        expect(screen.getByTitle('Close')).toBeDefined();
+    });
+});

--- a/packages/app/src/components/Nav/index.tsx
+++ b/packages/app/src/components/Nav/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import { useAuthContext } from '../../context/AuthContext';
+import MobileMenuButton from './MobileMenuButton';
 import NavLogo from './NavLogo';
 
 function Nav(): JSX.Element {
@@ -24,34 +25,13 @@ function Nav(): JSX.Element {
                             <NavLogo />
                         </Link>
                     </div>
+
                     {/* The button svg (menu or 'x') that is displayed on small screens */}
-                    <button
-                        className="focus:text-gray-100 focus:outline-none hover:text-gray-100 sm:hidden"
-                        type="button"
-                        onClick={() => setIsMobileLinksOpen(!isMobileLinksOpen)}
-                    >
-                        <svg
-                            viewBox="0 0 20 20"
-                            fill="currentColor"
-                            className="w-8 h-8 fill-current"
-                        >
-                            {isMobileLinksOpen ? (
-                                // The 'X' svg
-                                <path
-                                    fillRule="evenodd"
-                                    d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                                    clipRule="evenodd"
-                                ></path>
-                            ) : (
-                                // The 'menu' svg
-                                <path
-                                    fillRule="evenodd"
-                                    d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
-                                    clipRule="evenodd"
-                                ></path>
-                            )}
-                        </svg>
-                    </button>
+                    <MobileMenuButton
+                        isTriggered={isMobileLinksOpen}
+                        clickAction={() => setIsMobileLinksOpen(!isMobileLinksOpen)}
+                    />
+
                     {/* The nav links that are displayed on larger screens */}
                     <div className="hidden sm:block items-center text-xl">
                         {!isFetchingToken && !token && (


### PR DESCRIPTION
Refactor the nav bar to encapsulate the mobile menu button (and icon) in their own separate components, which also provides the opportunity to add some unit tests.