### PR TITLE
Add context user information to auth context

### DIFF
--- a/packages/api/@types/express/index.d.ts
+++ b/packages/api/@types/express/index.d.ts
@@ -4,6 +4,8 @@ declare global {
     namespace Express {
         interface User {
             id: string;
+            firstName: string;
+            lastName: string;
         }
     }
 }

--- a/packages/api/src/auth/__tests__/auth.resolver.spec.ts
+++ b/packages/api/src/auth/__tests__/auth.resolver.spec.ts
@@ -77,7 +77,13 @@ describe('Auth resolver', () => {
 
     describe('login mutation', () => {
         it('returns an access token if user is authenticated', async () => {
-            const req = {} as Request;
+            const req = {
+                user: {
+                    id: mockSavedOliver.id,
+                    firstName: mockSavedOliver.firstName,
+                    lastName: mockSavedOliver.lastName
+                }
+            } as Request;
             const res: any = {
                 cookie: jest.fn()
             };
@@ -96,7 +102,13 @@ describe('Auth resolver', () => {
 
             expect(result).toEqual(
                 expect.objectContaining({
-                    accessToken: fakeToken
+                    accessToken: fakeToken,
+                    userInfo: expect.objectContaining({
+                        id: mockSavedOliver.id,
+                        firstName: mockSavedOliver.firstName,
+                        lastName: mockSavedOliver.lastName,
+                        displayName: `${mockSavedOliver.firstName} ${mockSavedOliver.lastName}`
+                    })
                 })
             );
 

--- a/packages/api/src/auth/auth.resolver.ts
+++ b/packages/api/src/auth/auth.resolver.ts
@@ -34,7 +34,13 @@ export class AuthResolver {
         const refreshToken = this.authService.generateRefreshToken(user);
         res.cookie('qid', refreshToken, { httpOnly: true });
         return {
-            accessToken
+            accessToken,
+            userInfo: {
+                id: user.id,
+                firstName: user.firstName,
+                lastName: user.lastName,
+                displayName: `${user.firstName} ${user.lastName}`
+            }
         };
     }
 

--- a/packages/api/src/auth/dto/login-response.dto.ts
+++ b/packages/api/src/auth/dto/login-response.dto.ts
@@ -1,7 +1,25 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
 @ObjectType()
+class AuthUserInfo {
+    @Field()
+    id: string;
+
+    @Field()
+    firstName: string;
+
+    @Field()
+    lastName: string;
+
+    @Field()
+    displayName: string;
+}
+
+@ObjectType()
 export class LoginResponse {
     @Field({ nullable: true })
     accessToken: string;
+
+    @Field({ nullable: true })
+    userInfo: AuthUserInfo;
 }

--- a/packages/api/test/auth.e2e-spec.ts
+++ b/packages/api/test/auth.e2e-spec.ts
@@ -75,8 +75,16 @@ describe('Auth resolver (e2e)', () => {
                     variables: { loginInput: { email: oliver.email, password: oliver.password } }
                 })
                 .expect(({ body }) => {
-                    const { accessToken } = body.data.login;
+                    const { accessToken, userInfo } = body.data.login;
                     expect(accessToken.length).toBeGreaterThan(0);
+                    expect(userInfo).toEqual(
+                        expect.objectContaining({
+                            id: expect.any(String),
+                            firstName: oliver.firstName,
+                            lastName: oliver.lastName,
+                            displayName: `${oliver.firstName} ${oliver.lastName}`
+                        })
+                    );
                 });
         });
 

--- a/packages/api/test/utils/constants.ts
+++ b/packages/api/test/utils/constants.ts
@@ -52,6 +52,12 @@ export const loginOp = `
 mutation Login($loginInput: LoginInput!) {
     login(loginInput: $loginInput) {
         accessToken
+        userInfo {
+            id
+            firstName
+            lastName
+            displayName
+        }
     }
 }`;
 

--- a/packages/app/src/components/LoginForm/index.tsx
+++ b/packages/app/src/components/LoginForm/index.tsx
@@ -9,6 +9,12 @@ const loginOp = `
 mutation Login($loginInput: LoginInput!) {
   login(loginInput: $loginInput) {
     accessToken
+    userInfo {
+        id
+        firstName
+        lastName
+        displayName
+    }
   }
 }
 `;
@@ -33,7 +39,7 @@ function LoginForm(): JSX.Element {
             if (data) {
                 setAuthError('');
                 clearForm();
-                login(data.login.accessToken, () => {
+                login(data.login, () => {
                     navigate(from as string);
                 });
             }
@@ -44,7 +50,7 @@ function LoginForm(): JSX.Element {
                 } else {
                     setAuthError('Unexpected error. Please try again.');
                 }
-                login('');
+                login({ accessToken: '' });
             }
         },
         onError: (error) => {

--- a/packages/app/src/types/index.tsx
+++ b/packages/app/src/types/index.tsx
@@ -2,6 +2,15 @@ export interface User {
     id: string;
     displayName: string;
     email: string;
+    firstName: string;
+    lastName: string;
+}
+
+export type ContextUserInfo = Pick<User, 'id' | 'displayName' | 'firstName' | 'lastName'>;
+
+export interface LoginResponseData {
+    accessToken: string;
+    userInfo?: ContextUserInfo;
 }
 
 export enum UserListView {


### PR DESCRIPTION
Add basic context user information (`id`, `displayName`, `firstName`, and `lastName`) to the auth context after successful login.

Fixes #65 