### PR TITLE
Add user id to upload avatar mutation

### DIFF
--- a/packages/api/src/avatar/dto/avatar-upload.dto.ts
+++ b/packages/api/src/avatar/dto/avatar-upload.dto.ts
@@ -1,0 +1,11 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { FileUpload, GraphQLUpload } from 'graphql-upload';
+
+@InputType()
+export class AvatarUploadInput {
+    @Field()
+    userId: string;
+
+    @Field(() => GraphQLUpload)
+    image: Promise<FileUpload>;
+}

--- a/packages/api/test/avatar.e2e-spec.ts
+++ b/packages/api/test/avatar.e2e-spec.ts
@@ -90,6 +90,7 @@ describe('Avatar resolver (e2e)', () => {
             const testFile = `${__dirname}/../avatars/default/avatar.png`;
 
             const variables = {
+                userId: user.id,
                 image: null
             };
 
@@ -121,13 +122,14 @@ describe('Avatar resolver (e2e)', () => {
             const res = {} as Response;
             const testFile = `${__dirname}/../avatars/default/avatar.png`;
             const stream = fs.createReadStream(testFile);
-            const image: FileUpload = {
+            const image: Promise<FileUpload> = Promise.resolve({
                 createReadStream: () => stream,
                 filename: 'avatar.png',
                 mimetype: 'image/png',
-                encoding: 'bufffer'
-            };
-            await avatarResolver.avatarUpload(image, { req, res });
+                encoding: 'buffer'
+            });
+
+            await avatarResolver.avatarUpload({ userId: user.id, image }, { req, res });
         });
 
         it("fetches a user's avatar based on key", async () => {

--- a/packages/api/test/utils/constants.ts
+++ b/packages/api/test/utils/constants.ts
@@ -75,8 +75,8 @@ mutation RefreshAccessToken {
 `;
 
 export const avatarUploadOp = `
-mutation AvatarUpload ($image: Upload!) {
-    avatarUpload(image: $image)
+mutation AvatarUpload ($userId: String!, $image: Upload!) {
+    avatarUpload(avatarData: { userId: $userId, image: $image })
 }
 `;
 

--- a/packages/app/src/components/FileUpload/index.tsx
+++ b/packages/app/src/components/FileUpload/index.tsx
@@ -3,16 +3,17 @@ import useFileUpload from '../../hooks/useFileUpload';
 import { Button } from '../common';
 
 const AvatarUploadOp = `
-mutation AvatarUpload ($image: Upload!) {
-    avatarUpload(image: $image)
+mutation AvatarUpload ($userId: String!, $image: Upload!) {
+    avatarUpload(avatarData: { userId: $userId, image: $image })
 }
 `;
 
 interface FileUploadProps {
+    userId: string | undefined;
     onCancel?: () => void;
 }
 
-function FileUpload({ onCancel }: FileUploadProps): JSX.Element {
+function FileUpload({ userId, onCancel }: FileUploadProps): JSX.Element {
     const imgRef = useRef<HTMLImageElement>(null);
     const fileRef = useRef<HTMLInputElement>(null);
     const [highlight, setHighlight] = useState(false);
@@ -59,7 +60,7 @@ function FileUpload({ onCancel }: FileUploadProps): JSX.Element {
     };
 
     const handleFileUpload = () => {
-        const variables = { image: null, operationName: 'UploadAvatar' };
+        const variables = { image: null, userId, operationName: 'UploadAvatar' };
 
         fileUpload({ query: AvatarUploadOp, variables, file: image as File });
     };

--- a/packages/app/src/containers/UserDetailPage/index.tsx
+++ b/packages/app/src/containers/UserDetailPage/index.tsx
@@ -41,7 +41,7 @@ function UserDetailPage(): JSX.Element {
                 </button>
             </div>
             <Modal show={showModal} onClose={closeModal}>
-                <FileUpload onCancel={closeModal} />
+                <FileUpload userId={id} onCancel={closeModal} />
             </Modal>
         </>
     );


### PR DESCRIPTION
In order to improve the API security a bit more, this adds the requirement to include the user id in the `avatarUpload` mutation.  This id is checked against the context user on the server to determine if the avatar should be updated or not.