### PR TITLE
Client-side app fix

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -31,7 +31,8 @@
         "postcss": "8.4.12",
         "postcss-cli": "9.1.0",
         "tailwindcss": "3.0.23",
-        "vite": "2.8.6"
+        "vite": "2.8.6",
+        "vite-plugin-environment": "1.1.1"
     },
     "jest": {
         "roots": [

--- a/packages/app/src/dataservice.ts
+++ b/packages/app/src/dataservice.ts
@@ -12,7 +12,7 @@ interface QueryPayload {
     file?: File;
 }
 
-const graphqlEndpoint = `${import.meta.env.VITE_API_BASEURL}/graphql`;
+const graphqlEndpoint = `${process.env.VITE_API_BASEURL}/graphql`;
 
 export function makeGraphQLQuery({
     queryKey

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -1,26 +1,21 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-        "target": "ESNext",
-        "lib": [
-            "dom",
-            "dom.iterable",
-            "esnext"
-        ],
+        "target": "es2020",
+        "lib": ["dom", "dom.iterable", "esnext"],
         "allowJs": true,
         "skipLibCheck": false,
         "useDefineForClassFields": true,
         "esModuleInterop": true,
         "strict": true,
         "forceConsistentCasingInFileNames": true,
-        "module": "ESNext",
+        "module": "es2020",
         "moduleResolution": "Node",
         "isolatedModules": true,
         "resolveJsonModule": true,
         "noEmit": true,
         "jsx": "react-jsx"
     },
-    "include": [ "src" ],
+    "include": ["src"],
     "references": [{ "path": "./tsconfig.node.json" }]
-
 }

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import EnvironmentPlugin from 'vite-plugin-environment';
 
 // https://vitejs.dev/config/
 export default defineConfig({
     server: {
         port: 4200
     },
-    plugins: [react()]
+    plugins: [react(), EnvironmentPlugin('all')]
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2399,9 +2399,9 @@
     "@types/react" "*"
 
 "@types/react@*":
-  version "18.0.9"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.9.tgz#d6712a38bd6cd83469603e7359511126f122e878"
-  integrity sha512-9bjbg1hJHUm4De19L1cHiW0Jvx3geel6Qczhjd0qY5VKVE2X5+x77YxAepuCwVh4vrgZJdgEJw48zrhRIeF4Nw==
+  version "17.0.42"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.42.tgz#8242b9219bf8a911c47f248e327206fea3f4ee5a"
+  integrity sha512-nuab3x3CpJ7VFeNA+3HTUuEkvClYHXqWtWd7Ud6AZYW7Z3NH9WKtgU+tFB0ZLcHq+niB/HnzLcaZPqMJ95+k5Q==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -5792,9 +5792,9 @@ globals@^11.1.0:
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^13.6.0, globals@^13.9.0:
-  version "13.13.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.13.0.tgz#ac32261060d8070e2719dd6998406e27d2b5727b"
-  integrity sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==
+  version "13.14.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.14.0.tgz#daf3ff9b4336527cf56e98330b6f64bea9aff9df"
+  integrity sha512-ERO68sOYwm5UuLvSJTY7w7NP2c8S4UcXs3X1GBX8cwOr+ShOcDBbCY5mH4zxz0jsYCdJ8ve8Mv9n2YGJMB1aeg==
   dependencies:
     type-fest "^0.20.2"
 
@@ -9079,9 +9079,9 @@ react-is@^17.0.1:
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-query@*:
-  version "3.38.1"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.38.1.tgz#4892304dae7eca7fa0ab5c8ae3e9748f0fca2df9"
-  integrity sha512-CM9hsz6oib17hsBguGaMJr+a0swMzou2gvNHHjAusnXvkfTx6CTzx0Iwuplox1jI2j3WiY91BGrcIN6bp1n1Iw==
+  version "3.39.0"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.39.0.tgz#0caca7b0da98e65008bbcd4df0d25618c2100050"
+  integrity sha512-Od0IkSuS79WJOhzWBx/ys0x13+7wFqgnn64vBqqAAnZ9whocVhl/y1padD5uuZ6EIkXbFbInax0qvY7zGM0thA==
   dependencies:
     "@babel/runtime" "^7.5.5"
     broadcast-channel "^3.4.1"
@@ -10856,6 +10856,11 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vite-plugin-environment@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/vite-plugin-environment/-/vite-plugin-environment-1.1.1.tgz#c442b42eefcccd610d7882e6dd5ccbc29e26dfa5"
+  integrity sha512-kbUAZaqmiHap+7aqRfMolRGzCGhJSU45qDjgLM11DpSDzmiI5JL4EzdyAIUZ4g0WrO88EV2cdcq2fpNYuJ17Pg==
 
 vite@2.8.6:
   version "2.8.6"


### PR DESCRIPTION
Few chores to fix the client-side app:
* Force `@types/react` to v17 in `yarn.lock`.  This was a manual update so need to ensure it is not committed/updated with the next generated lock file.
* Add `vite-plugin-environment` to convert `import.meta.env` to `process.env`.  Seemed like the path of least resistance to get the jest tests to not complain.
