### PR TITLE
Add 'secure' to refresh token cookie

### DIFF
--- a/packages/api/src/auth/__tests__/auth.resolver.spec.ts
+++ b/packages/api/src/auth/__tests__/auth.resolver.spec.ts
@@ -114,7 +114,8 @@ describe('Auth resolver', () => {
 
             expect(res.cookie).toHaveBeenCalledWith('qid', fakeToken, {
                 httpOnly: true,
-                sameSite: 'none'
+                sameSite: 'none',
+                secure: true
             });
         });
     });
@@ -170,7 +171,8 @@ describe('Auth resolver', () => {
 
             expect(res.cookie).toHaveBeenCalledWith('qid', fakeToken, {
                 httpOnly: true,
-                sameSite: 'none'
+                sameSite: 'none',
+                secure: true
             });
         });
 

--- a/packages/api/src/auth/auth.resolver.ts
+++ b/packages/api/src/auth/auth.resolver.ts
@@ -32,7 +32,7 @@ export class AuthResolver {
 
         const accessToken = this.authService.generateAccessToken(user);
         const refreshToken = this.authService.generateRefreshToken(user);
-        res.cookie('qid', refreshToken, { httpOnly: true, sameSite: 'none' });
+        res.cookie('qid', refreshToken, { httpOnly: true, sameSite: 'none', secure: true });
         return {
             accessToken,
             userInfo: {
@@ -80,7 +80,11 @@ export class AuthResolver {
                     const accessToken = this.authService.generateAccessToken(user);
                     const refreshToken = this.authService.generateRefreshToken(user);
 
-                    res.cookie('qid', refreshToken, { httpOnly: true, sameSite: 'none' });
+                    res.cookie('qid', refreshToken, {
+                        httpOnly: true,
+                        sameSite: 'none',
+                        secure: true
+                    });
 
                     return {
                         accessToken


### PR DESCRIPTION
Add the `secure` option for the refresh token cookie.  This is required since the `sameSite` option is set to `'none'`.

Fixes #150 